### PR TITLE
Fix vaDriverInit

### DIFF
--- a/src/media_drv_init.c
+++ b/src/media_drv_init.c
@@ -2774,4 +2774,13 @@ __vaDriverInit_0_34 (VADriverContextP ctx)
   return ret;
 }
 
+VAStatus DLL_EXPORT VA_DRIVER_INIT_FUNC (VADriverContextP ctx);
+VAStatus
+VA_DRIVER_INIT_FUNC (VADriverContextP ctx)
+{
+  VAStatus ret = VA_STATUS_ERROR_UNKNOWN;
+
+  ret = va_driver_init (ctx);
+  return ret;
+}
 


### PR DESCRIPTION
Direct modification of vaDriverInit_0_34 to VA_DRIVER_INIT_FUNC will make this hybrid driver unable to work with i965 driver.

Add instead of modification will solve this. Then the hybrid driver could work independently or as a plugin for i965.

Sorry for that I am not a arch user and I cannot comment at https://aur.archlinux.org/packages/intel-hybrid-codec-driver-git